### PR TITLE
Remove unnecessary GEM_HOST_API_KEY environment variable

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -232,8 +232,6 @@ jobs:
         chmod 0600 ~/.gem/credentials
 
     - name: Publish to GitHub Packages
-      env:
-        GEM_HOST_API_KEY: ${{ secrets.GITHUB_TOKEN }}
       run: |
         GEM_NAME=$(ls *.gem)
         echo "Publishing $GEM_NAME to GitHub Packages..."


### PR DESCRIPTION
The gem push --key github command uses the credentials file configured in the previous step, not an environment variable. The GitHub token is already properly configured in ~/.gem/credentials as the 'github' key.